### PR TITLE
sync with uapi/linux/can/netlink.h

### DIFF
--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -296,9 +296,9 @@ pub enum CanCtrlMode {
     /// Classic CAN DLC option
     CcLen8Dlc,
     /// CAN transiver automatically calculates TDCV
-    TDC_AUTO,
+    TdcAuto,
     /// TDCV is manually set up by user
-    TDC_MANUAL,
+    TdcManual,
     /// LIN mode
     Lin,
 }

--- a/src/nl/mod.rs
+++ b/src/nl/mod.rs
@@ -295,6 +295,12 @@ pub enum CanCtrlMode {
     NonIso,
     /// Classic CAN DLC option
     CcLen8Dlc,
+    /// CAN transiver automatically calculates TDCV
+    TDC_AUTO,
+    /// TDCV is manually set up by user
+    TDC_MANUAL,
+    /// LIN mode
+    Lin,
 }
 
 impl CanCtrlMode {


### PR DESCRIPTION
and add Lin mode

This allows us to use the lin patches from https://lore.kernel.org/netdev/43a8b0484e5b4e7d550a665aa4f7b37186d030f7.camel@hexdev.de/T/#m85fe61bfccd0dd95eb030e7b34bee63fec5a6cfb
